### PR TITLE
chore: release v0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "graph-api-benches"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "criterion",
  "graph-api-derive",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "graph-api-lib"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "derivative",
  "graph-api-simplegraph",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "graph-api-petgraph"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "criterion",
  "graph-api-benches",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "graph-api-simplegraph"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "criterion",
  "fastbloom",
@@ -483,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "graph-api-test"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "graph-api-derive",
  "graph-api-lib",

--- a/graph-api-benches/CHANGELOG.md
+++ b/graph-api-benches/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.3] - 2025-04-13
+
+### 🐛 Bug Fixes
+
+- *(deps)* Update rust crate rand to 0.9 (#26)
+
+
 ## [0.1.2] - 2025-04-13
 
 ### ⚙️ Miscellaneous Tasks

--- a/graph-api-benches/Cargo.toml
+++ b/graph-api-benches/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-api-benches"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "Benchmarking utilities and performance tests for the graph-api ecosystem"
 authors = ["Bryn Cooke"]
@@ -27,12 +27,12 @@ bench = false
 
 
 [dependencies]
-graph-api-lib = { version = "0.1.2", path = "../graph-api-lib" }
+graph-api-lib = { version = "0.1.3", path = "../graph-api-lib" }
 graph-api-derive = { version = "0.1.1", path = "../graph-api-derive" }
 uuid = { version = "1.11.0", features = ["v4"] }
 criterion = { version = "0.5", features = ["html_reports"] }
 rand = { version = "0.9" }
-graph-api-test = { version = "0.1.2", path = "../graph-api-test" }
+graph-api-test = { version = "0.1.3", path = "../graph-api-test" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/graph-api-book/book.toml
+++ b/graph-api-book/book.toml
@@ -11,10 +11,10 @@ git-repository-url = "https://github.com/BrynCooke/graph-api"
 git-repository-icon = "fa-github"
 
 [preprocessor.variables.variables]
-version = "0.1.2"  # Legacy variable - will be removed once all md files are updated
-lib_version = "0.1.2"
+version = "0.1.3"  # Legacy variable - will be removed once all md files are updated
+lib_version = "0.1.3"
 derive_version = "0.1.1"
-simplegraph_version = "0.1.2"
-petgraph_version = "0.1.2"
-test_version = "0.1.2"
-benches_version = "0.1.2"
+simplegraph_version = "0.1.3"
+petgraph_version = "0.1.3"
+test_version = "0.1.3"
+benches_version = "0.1.3"

--- a/graph-api-lib/CHANGELOG.md
+++ b/graph-api-lib/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.3] - 2025-04-13
+
+### ⚙️ Miscellaneous Tasks
+
+- Update Cargo.toml dependencies
+
+
 ## [0.1.2] - 2025-04-13
 
 ### ⚙️ Miscellaneous Tasks

--- a/graph-api-lib/Cargo.toml
+++ b/graph-api-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-api-lib"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "Core library for the graph-api ecosystem - a flexible, type-safe API for working with in-memory graphs in Rust"
 authors = ["Bryn Cooke"]

--- a/graph-api-petgraph/CHANGELOG.md
+++ b/graph-api-petgraph/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.3] - 2025-04-13
+
+### 🐛 Bug Fixes
+
+- *(deps)* Update rust crate rand to 0.9 (#26)
+
+
 ## [0.1.2] - 2025-04-13
 
 ### ⚙️ Miscellaneous Tasks

--- a/graph-api-petgraph/Cargo.toml
+++ b/graph-api-petgraph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-api-petgraph"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "Integration between graph-api and petgraph - use graph-api's traversal system with petgraph structures"
 authors = ["Bryn Cooke"]
@@ -15,7 +15,7 @@ categories = ["data-structures", "algorithms"]
 bench = false
 
 [dependencies]
-graph-api-lib = { version = "0.1.2", path = "../graph-api-lib", features = ["petgraph"] }
+graph-api-lib = { version = "0.1.3", path = "../graph-api-lib", features = ["petgraph"] }
 petgraph = { workspace = true }
 
 [dev-dependencies]

--- a/graph-api-simplegraph/CHANGELOG.md
+++ b/graph-api-simplegraph/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.3] - 2025-04-13
+
+### 🐛 Bug Fixes
+
+- *(deps)* Update rust crate fastbloom to 0.9.0 (#21)
+- *(deps)* Update rust crate rand to 0.9 (#26)
+
+
 ## [0.1.2] - 2025-04-13
 
 ### ⚙️ Miscellaneous Tasks

--- a/graph-api-simplegraph/Cargo.toml
+++ b/graph-api-simplegraph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-api-simplegraph"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "A simple, efficient graph implementation for the graph-api ecosystem with support for indexing"
 authors = ["Bryn Cooke"]
@@ -16,7 +16,7 @@ categories = ["data-structures", "memory-management"]
 bench = false
 
 [dependencies]
-graph-api-lib = { version = "0.1.2", path = "../graph-api-lib" }
+graph-api-lib = { version = "0.1.3", path = "../graph-api-lib" }
 paste = "1.0.15"
 fastbloom = "0.9.0"
 rphonetic = "3.0.1"

--- a/graph-api-test/CHANGELOG.md
+++ b/graph-api-test/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.3] - 2025-04-13
+
+### ⚙️ Miscellaneous Tasks
+
+- Updated the following local packages: graph-api-lib
+
+
 ## [0.1.2] - 2025-04-13
 
 ### ⚙️ Miscellaneous Tasks

--- a/graph-api-test/Cargo.toml
+++ b/graph-api-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-api-test"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "Test utilities and property-based testing for the graph-api ecosystem"
 authors = ["Bryn Cooke"]
@@ -24,7 +24,7 @@ graph-clear = []
 
 
 [dependencies]
-graph-api-lib = { version = "0.1.2", path = "../graph-api-lib" }
+graph-api-lib = { version = "0.1.3", path = "../graph-api-lib" }
 graph-api-derive = { version = "0.1.1", path = "../graph-api-derive" }
 thiserror = "2.0.3"
 proptest = "1.5.0"


### PR DESCRIPTION



## 🤖 New release

* `graph-api-lib`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `graph-api-simplegraph`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `graph-api-benches`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `graph-api-petgraph`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `graph-api-test`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `graph-api-lib`

<blockquote>

## [0.1.3] - 2025-04-13

### ⚙️ Miscellaneous Tasks

- Update Cargo.toml dependencies
</blockquote>

## `graph-api-simplegraph`

<blockquote>

## [0.1.3] - 2025-04-13

### 🐛 Bug Fixes

- *(deps)* Update rust crate fastbloom to 0.9.0 (#21)
- *(deps)* Update rust crate rand to 0.9 (#26)
</blockquote>

## `graph-api-benches`

<blockquote>

## [0.1.3] - 2025-04-13

### 🐛 Bug Fixes

- *(deps)* Update rust crate rand to 0.9 (#26)
</blockquote>

## `graph-api-petgraph`

<blockquote>

## [0.1.3] - 2025-04-13

### 🐛 Bug Fixes

- *(deps)* Update rust crate rand to 0.9 (#26)
</blockquote>

## `graph-api-test`

<blockquote>

## [0.1.3] - 2025-04-13

### ⚙️ Miscellaneous Tasks

- Updated the following local packages: graph-api-lib
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).