### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "graph-api-benches"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "criterion",
  "graph-api-derive",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "graph-api-derive"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "case",
  "graph-api-lib",
@@ -483,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "graph-api-test"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "graph-api-derive",
  "graph-api-lib",

--- a/graph-api-benches/CHANGELOG.md
+++ b/graph-api-benches/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.4] - 2025-04-13
+
+### ⚙️ Miscellaneous Tasks
+
+- Updated the following local packages: graph-api-derive, graph-api-test
+
+
 ## [0.1.3] - 2025-04-13
 
 ### 🐛 Bug Fixes

--- a/graph-api-benches/Cargo.toml
+++ b/graph-api-benches/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-api-benches"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "Benchmarking utilities and performance tests for the graph-api ecosystem"
 authors = ["Bryn Cooke"]
@@ -28,11 +28,11 @@ bench = false
 
 [dependencies]
 graph-api-lib = { version = "0.1.3", path = "../graph-api-lib" }
-graph-api-derive = { version = "0.1.1", path = "../graph-api-derive" }
+graph-api-derive = { version = "0.1.2", path = "../graph-api-derive" }
 uuid = { version = "1.11.0", features = ["v4"] }
 criterion = { version = "0.5", features = ["html_reports"] }
 rand = { version = "0.9" }
-graph-api-test = { version = "0.1.3", path = "../graph-api-test" }
+graph-api-test = { version = "0.1.4", path = "../graph-api-test" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/graph-api-book/book.toml
+++ b/graph-api-book/book.toml
@@ -13,8 +13,8 @@ git-repository-icon = "fa-github"
 [preprocessor.variables.variables]
 version = "0.1.3"  # Legacy variable - will be removed once all md files are updated
 lib_version = "0.1.3"
-derive_version = "0.1.1"
+derive_version = "0.1.2"
 simplegraph_version = "0.1.3"
 petgraph_version = "0.1.3"
-test_version = "0.1.3"
-benches_version = "0.1.3"
+test_version = "0.1.4"
+benches_version = "0.1.4"

--- a/graph-api-derive/CHANGELOG.md
+++ b/graph-api-derive/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+

--- a/graph-api-derive/Cargo.toml
+++ b/graph-api-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-api-derive"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "Derive macros for the graph-api ecosystem - provides type-safe vertex and edge extensions"
 authors = ["Bryn Cooke"]

--- a/graph-api-test/CHANGELOG.md
+++ b/graph-api-test/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.4] - 2025-04-13
+
+### ⚙️ Miscellaneous Tasks
+
+- Updated the following local packages: graph-api-derive
+
+
 ## [0.1.3] - 2025-04-13
 
 ### ⚙️ Miscellaneous Tasks

--- a/graph-api-test/Cargo.toml
+++ b/graph-api-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-api-test"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "Test utilities and property-based testing for the graph-api ecosystem"
 authors = ["Bryn Cooke"]
@@ -25,7 +25,7 @@ graph-clear = []
 
 [dependencies]
 graph-api-lib = { version = "0.1.3", path = "../graph-api-lib" }
-graph-api-derive = { version = "0.1.1", path = "../graph-api-derive" }
+graph-api-derive = { version = "0.1.2", path = "../graph-api-derive" }
 thiserror = "2.0.3"
 proptest = "1.5.0"
 uuid = { version = "1.11.0", features = ["v4"] }


### PR DESCRIPTION



## 🤖 New release

* `graph-api-derive`: 0.1.1 -> 0.1.2
* `graph-api-test`: 0.1.3 -> 0.1.4
* `graph-api-benches`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>


## `graph-api-test`

<blockquote>

## [0.1.4] - 2025-04-13

### ⚙️ Miscellaneous Tasks

- Updated the following local packages: graph-api-derive
</blockquote>

## `graph-api-benches`

<blockquote>

## [0.1.4] - 2025-04-13

### ⚙️ Miscellaneous Tasks

- Updated the following local packages: graph-api-derive, graph-api-test
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).