### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "graph-api-benches"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "criterion",
  "graph-api-derive",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "graph-api-derive"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "case",
  "graph-api-lib",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "graph-api-lib"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "derivative",
  "graph-api-simplegraph",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "graph-api-petgraph"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "criterion",
  "graph-api-benches",
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "graph-api-simplegraph"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "criterion",
  "fastbloom",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "graph-api-test"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "graph-api-derive",
  "graph-api-lib",

--- a/graph-api-benches/CHANGELOG.md
+++ b/graph-api-benches/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.4] - 2025-04-13
+
+### ⚙️ Miscellaneous Tasks
+
+- Updated the following local packages: graph-api-lib, graph-api-derive, graph-api-test
+
+
 ## [0.1.3] - 2025-04-13
 
 ### 🐛 Bug Fixes

--- a/graph-api-benches/Cargo.toml
+++ b/graph-api-benches/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-api-benches"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "Benchmarking utilities and performance tests for the graph-api ecosystem"
 authors = ["Bryn Cooke"]
@@ -27,12 +27,12 @@ bench = false
 
 
 [dependencies]
-graph-api-lib = { version = "0.1.3", path = "../graph-api-lib" }
-graph-api-derive = { version = "0.1.1", path = "../graph-api-derive" }
+graph-api-lib = { version = "0.1.4", path = "../graph-api-lib" }
+graph-api-derive = { version = "0.1.2", path = "../graph-api-derive" }
 uuid = { version = "1.11.0", features = ["v4"] }
 criterion = { version = "0.5", features = ["html_reports"] }
 rand = { version = "0.9" }
-graph-api-test = { version = "0.1.3", path = "../graph-api-test" }
+graph-api-test = { version = "0.1.4", path = "../graph-api-test" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/graph-api-book/Cargo.toml
+++ b/graph-api-book/Cargo.toml
@@ -14,7 +14,7 @@ publish = false
 
 
 [dependencies]
-graph-api-derive = { version = "0.1.1", path = "../graph-api-derive" }
-graph-api-lib = { version = "0.1.3", path = "../graph-api-lib" }
-graph-api-simplegraph = { version = "0.1.3", path = "../graph-api-simplegraph" }
+graph-api-derive = { version = "0.1.2", path = "../graph-api-derive" }
+graph-api-lib = { version = "0.1.4", path = "../graph-api-lib" }
+graph-api-simplegraph = { version = "0.1.4", path = "../graph-api-simplegraph" }
 uuid = "1.16.0"

--- a/graph-api-derive/CHANGELOG.md
+++ b/graph-api-derive/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.2] - 2025-04-13
+
+### ⚙️ Miscellaneous Tasks
+
+- Local dependencies all have versions (#42)
+
+

--- a/graph-api-derive/Cargo.toml
+++ b/graph-api-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-api-derive"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "Derive macros for the graph-api ecosystem - provides type-safe vertex and edge extensions"
 authors = ["Bryn Cooke"]
@@ -26,4 +26,4 @@ insta = { version = "1.39.0", features = ["yaml"] }
 trybuild = "1.0"
 proc-macro2 = { version = "1.0.82", features = [] }
 prettyplease = "0.2.29"
-graph-api-lib = { version = "0.1.3", path = "../graph-api-lib" }
+graph-api-lib = { version = "0.1.4", path = "../graph-api-lib" }

--- a/graph-api-lib/CHANGELOG.md
+++ b/graph-api-lib/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.4] - 2025-04-13
+
+### ⚙️ Miscellaneous Tasks
+
+- Local dependencies all have versions (#42)
+
+
 ## [0.1.3] - 2025-04-13
 
 ### ⚙️ Miscellaneous Tasks

--- a/graph-api-lib/Cargo.toml
+++ b/graph-api-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-api-lib"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "Core library for the graph-api ecosystem - a flexible, type-safe API for working with in-memory graphs in Rust"
 authors = ["Bryn Cooke"]
@@ -23,5 +23,5 @@ derivative = "2.2.0"
 include-doc = "0.2.1"
 
 [dev-dependencies]
-graph-api-simplegraph = { version = "0.1.3", path = "../graph-api-simplegraph" }
-graph-api-test = { version = "0.1.3", path = "../graph-api-test" }
+graph-api-simplegraph = { version = "0.1.4", path = "../graph-api-simplegraph" }
+graph-api-test = { version = "0.1.4", path = "../graph-api-test" }

--- a/graph-api-petgraph/CHANGELOG.md
+++ b/graph-api-petgraph/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.4] - 2025-04-13
+
+### ⚙️ Miscellaneous Tasks
+
+- Local dependencies all have versions (#42)
+
+
 ## [0.1.3] - 2025-04-13
 
 ### 🐛 Bug Fixes

--- a/graph-api-petgraph/Cargo.toml
+++ b/graph-api-petgraph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-api-petgraph"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "Integration between graph-api and petgraph - use graph-api's traversal system with petgraph structures"
 authors = ["Bryn Cooke"]
@@ -15,12 +15,12 @@ categories = ["data-structures", "algorithms"]
 bench = false
 
 [dependencies]
-graph-api-lib = { version = "0.1.3", path = "../graph-api-lib", features = ["petgraph"] }
+graph-api-lib = { version = "0.1.4", path = "../graph-api-lib", features = ["petgraph"] }
 petgraph = { workspace = true }
 
 [dev-dependencies]
-graph-api-test = { version = "0.1.3", path = "../graph-api-test", features = ["graph-clear"] }
-graph-api-benches = { version = "0.1.3", path = "../graph-api-benches", features = ["graph-clear"] }
+graph-api-test = { version = "0.1.4", path = "../graph-api-test", features = ["graph-clear"] }
+graph-api-benches = { version = "0.1.4", path = "../graph-api-benches", features = ["graph-clear"] }
 criterion = { version = "0.5", features = ["html_reports"] }
 
 [[bench]]

--- a/graph-api-simplegraph/CHANGELOG.md
+++ b/graph-api-simplegraph/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.4] - 2025-04-13
+
+### ⚙️ Miscellaneous Tasks
+
+- Local dependencies all have versions (#42)
+
+
 ## [0.1.3] - 2025-04-13
 
 ### 🐛 Bug Fixes

--- a/graph-api-simplegraph/Cargo.toml
+++ b/graph-api-simplegraph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-api-simplegraph"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "A simple, efficient graph implementation for the graph-api ecosystem with support for indexing"
 authors = ["Bryn Cooke"]
@@ -16,7 +16,7 @@ categories = ["data-structures", "memory-management"]
 bench = false
 
 [dependencies]
-graph-api-lib = { version = "0.1.3", path = "../graph-api-lib" }
+graph-api-lib = { version = "0.1.4", path = "../graph-api-lib" }
 paste = "1.0.15"
 fastbloom = "0.9.0"
 rphonetic = "3.0.1"
@@ -24,8 +24,8 @@ smallbox = "0.8.6"
 uuid = { version = "1.11.0", features = ["v4"] }
 
 [dev-dependencies]
-graph-api-test = { version = "0.1.3", path = "../graph-api-test", features = ["vertex-hash-index", "vertex-label-index", "vertex-full-text-index", "vertex-range-index", "edge-label-index"] }
-graph-api-benches = { version = "0.1.3", path = "../graph-api-benches", features = ["vertex-hash-index", "vertex-label-index", "vertex-full-text-index", "vertex-range-index", "edge-label-index"] }
+graph-api-test = { version = "0.1.4", path = "../graph-api-test", features = ["vertex-hash-index", "vertex-label-index", "vertex-full-text-index", "vertex-range-index", "edge-label-index"] }
+graph-api-benches = { version = "0.1.4", path = "../graph-api-benches", features = ["vertex-hash-index", "vertex-label-index", "vertex-full-text-index", "vertex-range-index", "edge-label-index"] }
 criterion = { version = "0.5", features = ["html_reports"] }
 
 [[bench]]

--- a/graph-api-test/CHANGELOG.md
+++ b/graph-api-test/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.4] - 2025-04-13
+
+### ⚙️ Miscellaneous Tasks
+
+- Updated the following local packages: graph-api-lib, graph-api-derive
+
+
 ## [0.1.3] - 2025-04-13
 
 ### ⚙️ Miscellaneous Tasks

--- a/graph-api-test/Cargo.toml
+++ b/graph-api-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-api-test"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "Test utilities and property-based testing for the graph-api ecosystem"
 authors = ["Bryn Cooke"]
@@ -24,8 +24,8 @@ graph-clear = []
 
 
 [dependencies]
-graph-api-lib = { version = "0.1.3", path = "../graph-api-lib" }
-graph-api-derive = { version = "0.1.1", path = "../graph-api-derive" }
+graph-api-lib = { version = "0.1.4", path = "../graph-api-lib" }
+graph-api-derive = { version = "0.1.2", path = "../graph-api-derive" }
 thiserror = "2.0.3"
 proptest = "1.5.0"
 uuid = { version = "1.11.0", features = ["v4"] }


### PR DESCRIPTION



## 🤖 New release

* `graph-api-lib`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `graph-api-simplegraph`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `graph-api-derive`: 0.1.1 -> 0.1.2
* `graph-api-petgraph`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `graph-api-test`: 0.1.3 -> 0.1.4
* `graph-api-benches`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `graph-api-lib`

<blockquote>

## [0.1.4] - 2025-04-13

### ⚙️ Miscellaneous Tasks

- Local dependencies all have versions (#42)
</blockquote>

## `graph-api-simplegraph`

<blockquote>

## [0.1.4] - 2025-04-13

### ⚙️ Miscellaneous Tasks

- Local dependencies all have versions (#42)
</blockquote>

## `graph-api-derive`

<blockquote>

## [0.1.2] - 2025-04-13

### ⚙️ Miscellaneous Tasks

- Local dependencies all have versions (#42)
</blockquote>

## `graph-api-petgraph`

<blockquote>

## [0.1.4] - 2025-04-13

### ⚙️ Miscellaneous Tasks

- Local dependencies all have versions (#42)
</blockquote>

## `graph-api-test`

<blockquote>

## [0.1.4] - 2025-04-13

### ⚙️ Miscellaneous Tasks

- Updated the following local packages: graph-api-lib, graph-api-derive
</blockquote>

## `graph-api-benches`

<blockquote>

## [0.1.4] - 2025-04-13

### ⚙️ Miscellaneous Tasks

- Updated the following local packages: graph-api-lib, graph-api-derive, graph-api-test
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).