### PR TITLE
fix: Projection visibility

### DIFF
--- a/graph-api-book/src/user_guide/derive_macros.md
+++ b/graph-api-book/src/user_guide/derive_macros.md
@@ -113,7 +113,7 @@ When you apply `#[derive(EdgeExt)]` to an enum, similar types are generated:
 ```rust,noplayground
 // Given this edge definition
 #[derive(EdgeExt)]
-enum Edge {
+pub enum Edge {
     Created,
     Follows,
     Liked { timestamp: String },

--- a/graph-api-book/src/user_guide/getting_started/first_graph.rs
+++ b/graph-api-book/src/user_guide/getting_started/first_graph.rs
@@ -4,7 +4,7 @@ use graph_api_simplegraph::SimpleGraph;
 // ANCHOR: model
 // Define our vertex types using derive macro
 #[derive(Debug, Clone, VertexExt)]
-pub enum Vertex {
+enum Vertex {
     // A person vertex with name and age properties
     Person {
         name: String,

--- a/graph-api-derive/src/model.rs
+++ b/graph-api-derive/src/model.rs
@@ -31,7 +31,6 @@ pub(crate) struct Variant {
 
 #[cfg_attr(test, derive(Debug))]
 pub(crate) struct Field {
-    pub(crate) visibility: Visibility,
     pub(crate) ident: Ident,
     pub(crate) ty: Type,
     pub(crate) index_ident: Ident,
@@ -146,7 +145,6 @@ impl TryFrom<DeriveType<'_>> for Model {
                                 .iter()
                                 .map(|field| {
                                     let mut field_model = Field {
-                                        visibility: model.visibility.clone(),
                                         ident: field
                                             .ident
                                             .as_ref()

--- a/graph-api-derive/src/snapshots/graph_api_derive__model__test__parse_enum.snap
+++ b/graph-api-derive/src/snapshots/graph_api_derive__model__test__parse_enum.snap
@@ -92,7 +92,6 @@ Model {
             variant_type: Named,
             fields: [
                 Field {
-                    visibility: Visibility::Inherited,
                     ident: Ident(
                         param1,
                     ),
@@ -122,7 +121,6 @@ Model {
                     full_text: false,
                 },
                 Field {
-                    visibility: Visibility::Inherited,
                     ident: Ident(
                         param2,
                     ),

--- a/graph-api-derive/tests/ui/private_model.rs
+++ b/graph-api-derive/tests/ui/private_model.rs
@@ -1,0 +1,28 @@
+use graph_api_derive::{EdgeExt, VertexExt};
+#[derive(Debug, Clone, VertexExt)]
+enum Vertex {
+    Person {
+        #[index(hash)]
+        name: String,
+        age: u64,
+    },
+    Project(Project),
+    Rust,
+}
+
+#[derive(Debug, Clone)]
+struct Project {
+    name: String,
+}
+
+#[derive(Debug, Clone, EdgeExt)]
+enum Edge {
+    Knows { since: i32 },
+    Created,
+    Language(Language),
+}
+#[derive(Debug, Clone)]
+struct Language {
+    name: String,
+}
+fn main() {}

--- a/graph-api-derive/tests/ui/pub_super_model.rs
+++ b/graph-api-derive/tests/ui/pub_super_model.rs
@@ -1,0 +1,40 @@
+use graph_api_lib::VertexReference;
+use graph_api_lib::VertexSearch;
+mod module {
+    use graph_api_derive::{EdgeExt, VertexExt};
+
+    #[derive(Debug, Clone, VertexExt)]
+    pub(super) enum Vertex {
+        Person {
+            #[index(hash)]
+            name: String,
+            age: u64,
+        },
+        Project(Project),
+        Rust,
+    }
+
+    #[derive(Debug, Clone)]
+    pub(super) struct Project {
+        name: String,
+    }
+
+    #[derive(Debug, Clone, EdgeExt)]
+    pub(super) enum Edge {
+        Knows { since: i32 },
+        Created,
+        Language(Language),
+    }
+    #[derive(Debug, Clone)]
+    pub(super) struct Language {
+        name: String,
+    }
+}
+
+fn main() {}
+
+fn test_projection(g: impl graph_api_lib::Graph<Vertex = module::Vertex, Edge = module::Edge>) {
+    g.walk()
+        .vertices(VertexSearch::scan())
+        .filter(|p, _| p.project::<module::Person<_>>().unwrap().name() == "bob");
+}


### PR DESCRIPTION
Projection types that were not public did not have sufficient visibility for use elsewhere. Now all projection items are pubic and we rely on the module to maintain overall visibility constraints.