### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "graph-api-benches"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "criterion",
  "graph-api-derive",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "graph-api-derive"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "case",
  "graph-api-lib",
@@ -483,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "graph-api-test"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "graph-api-derive",
  "graph-api-lib",
@@ -636,9 +636,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "linked-hash-map"

--- a/graph-api-benches/CHANGELOG.md
+++ b/graph-api-benches/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.6] - 2025-04-17
+
+### ⚙️ Miscellaneous Tasks
+
+- Updated the following local packages: graph-api-derive, graph-api-test
+
+
 ## [0.1.5] - 2025-04-13
 
 ### ⚙️ Miscellaneous Tasks

--- a/graph-api-benches/Cargo.toml
+++ b/graph-api-benches/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-api-benches"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 description = "Benchmarking utilities and performance tests for the graph-api ecosystem"
 authors = ["Bryn Cooke"]
@@ -28,11 +28,11 @@ bench = false
 
 [dependencies]
 graph-api-lib = { version = "0.1.4", path = "../graph-api-lib" }
-graph-api-derive = { version = "0.1.2", path = "../graph-api-derive" }
+graph-api-derive = { version = "0.1.3", path = "../graph-api-derive" }
 uuid = { version = "1.11.0", features = ["v4"] }
 criterion = { version = "0.5", features = ["html_reports"] }
 rand = { version = "0.9" }
-graph-api-test = { version = "0.1.5", path = "../graph-api-test" }
+graph-api-test = { version = "0.1.6", path = "../graph-api-test" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/graph-api-book/book.toml
+++ b/graph-api-book/book.toml
@@ -15,8 +15,8 @@ git-repository-icon = "fa-github"
 [preprocessor.variables.variables]
 version = "0.1.4"  # Legacy variable - will be removed once all md files are updated
 lib_version = "0.1.4"
-derive_version = "0.1.2"
+derive_version = "0.1.3"
 simplegraph_version = "0.1.4"
 petgraph_version = "0.1.4"
-test_version = "0.1.5"
-benches_version = "0.1.5"
+test_version = "0.1.6"
+benches_version = "0.1.6"

--- a/graph-api-derive/CHANGELOG.md
+++ b/graph-api-derive/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.3] - 2025-04-17
+
+### 🐛 Bug Fixes
+
+- Projection visibility (#64)
+
+
 ## [0.1.2] - 2025-04-13
 
 ### ⚙️ Miscellaneous Tasks

--- a/graph-api-derive/Cargo.toml
+++ b/graph-api-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-api-derive"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "Derive macros for the graph-api ecosystem - provides type-safe vertex and edge extensions"
 authors = ["Bryn Cooke"]

--- a/graph-api-test/CHANGELOG.md
+++ b/graph-api-test/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.6] - 2025-04-17
+
+### ⚙️ Miscellaneous Tasks
+
+- Updated the following local packages: graph-api-derive
+
+
 ## [0.1.5] - 2025-04-13
 
 ### 📚 Documentation

--- a/graph-api-test/Cargo.toml
+++ b/graph-api-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-api-test"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 description = "Test utilities and property-based testing for the graph-api ecosystem"
 authors = ["Bryn Cooke"]
@@ -25,7 +25,7 @@ graph-clear = []
 
 [dependencies]
 graph-api-lib = { version = "0.1.4", path = "../graph-api-lib" }
-graph-api-derive = { version = "0.1.2", path = "../graph-api-derive" }
+graph-api-derive = { version = "0.1.3", path = "../graph-api-derive" }
 thiserror = "2.0.3"
 proptest = "1.5.0"
 uuid = { version = "1.11.0", features = ["v4"] }


### PR DESCRIPTION



## 🤖 New release

* `graph-api-derive`: 0.1.2 -> 0.1.3
* `graph-api-test`: 0.1.5 -> 0.1.6
* `graph-api-benches`: 0.1.5 -> 0.1.6

<details><summary><i><b>Changelog</b></i></summary><p>

## `graph-api-derive`

<blockquote>

## [0.1.3] - 2025-04-17

### 🐛 Bug Fixes

- Projection visibility (#64)
</blockquote>

## `graph-api-test`

<blockquote>

## [0.1.6] - 2025-04-17

### ⚙️ Miscellaneous Tasks

- Updated the following local packages: graph-api-derive
</blockquote>

## `graph-api-benches`

<blockquote>

## [0.1.6] - 2025-04-17

### ⚙️ Miscellaneous Tasks

- Updated the following local packages: graph-api-derive, graph-api-test
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).