### PR TITLE
feat!: Move removal of elements to `SupportsElementRemoval`

### DIFF
--- a/graph-api-benches/Cargo.toml
+++ b/graph-api-benches/Cargo.toml
@@ -21,6 +21,7 @@ edge-label-index = []
 edge-hash-index = []
 edge-range-index = []
 graph-clear = []
+element-removal = []
 
 [lib]
 bench = false

--- a/graph-api-benches/src/index/mod.rs
+++ b/graph-api-benches/src/index/mod.rs
@@ -5,11 +5,3 @@ pub mod vertex_full_text;
 pub mod vertex_hash;
 pub mod vertex_label;
 pub mod vertex_range;
-
-// Re-export run functions
-pub use edge_label::run_benchmarks as run_edge_label_benchmarks;
-pub use no_index::run_benchmarks as run_no_index_benchmarks;
-pub use vertex_full_text::run_benchmarks as run_vertex_full_text_benchmarks;
-pub use vertex_hash::run_benchmarks as run_vertex_hash_benchmarks;
-pub use vertex_label::run_benchmarks as run_vertex_label_benchmarks;
-pub use vertex_range::run_benchmarks as run_vertex_range_benchmarks;

--- a/graph-api-benches/src/lib.rs
+++ b/graph-api-benches/src/lib.rs
@@ -63,37 +63,54 @@ macro_rules! bench_suite {
         // Run vertex label index benchmarks
         let mut vertex_label_group = criterion.benchmark_group("vertex_label_index");
         $crate::configure_group(&mut vertex_label_group);
-        $crate::index::run_vertex_label_benchmarks(&mut vertex_label_group, $setup);
+        $crate::index::vertex_label::bench_label_lookup(&mut vertex_label_group, $setup.clone());
+        $crate::index::vertex_label::bench_label_insertion(&mut vertex_label_group, $setup.clone());
+        $crate::index::vertex_label::bench_label_removal(&mut vertex_label_group, $setup.clone());
         vertex_label_group.finish();
 
         // Run vertex hash index benchmarks
         let mut vertex_hash_group = criterion.benchmark_group("vertex_hash_index");
         $crate::configure_group(&mut vertex_hash_group);
-        $crate::index::run_vertex_hash_benchmarks(&mut vertex_hash_group, $setup);
+        $crate::index::vertex_hash::bench_lookup(&mut vertex_hash_group, $setup.clone());
+        $crate::index::vertex_hash::bench_insertion(&mut vertex_hash_group, $setup.clone());
+        $crate::index::vertex_hash::bench_removal(&mut vertex_hash_group, $setup.clone());
         vertex_hash_group.finish();
 
         // Run vertex full-text index benchmarks
         let mut vertex_full_text_group = criterion.benchmark_group("vertex_full_text_index");
         $crate::configure_group(&mut vertex_full_text_group);
-        $crate::index::run_vertex_full_text_benchmarks(&mut vertex_full_text_group, $setup);
+        $crate::index::vertex_full_text::bench_lookup(&mut vertex_full_text_group, $setup.clone());
+        $crate::index::vertex_full_text::bench_insertion(
+            &mut vertex_full_text_group,
+            $setup.clone(),
+        );
+        $crate::index::vertex_full_text::bench_removal(&mut vertex_full_text_group, $setup.clone());
         vertex_full_text_group.finish();
 
         // Run vertex range index benchmarks
         let mut vertex_range_group = criterion.benchmark_group("vertex_range_index");
         $crate::configure_group(&mut vertex_range_group);
-        $crate::index::run_vertex_range_benchmarks(&mut vertex_range_group, $setup);
+        $crate::index::vertex_range::bench_lookup(&mut vertex_range_group, $setup.clone());
+        $crate::index::vertex_range::bench_insertion(&mut vertex_range_group, $setup.clone());
+        $crate::index::vertex_range::bench_removal(&mut vertex_range_group, $setup.clone());
         vertex_range_group.finish();
 
         // Run edge label index benchmarks
         let mut edge_label_group = criterion.benchmark_group("edge_label_index");
         $crate::configure_group(&mut edge_label_group);
-        $crate::index::run_edge_label_benchmarks(&mut edge_label_group, $setup);
+        $crate::index::edge_label::bench_lookup(&mut edge_label_group, $setup.clone());
+        $crate::index::edge_label::bench_insertion(&mut edge_label_group, $setup.clone());
+        $crate::index::edge_label::bench_removal(&mut edge_label_group, $setup.clone());
         edge_label_group.finish();
 
         // Run no-index benchmarks (baseline performance)
         let mut no_index_group = criterion.benchmark_group("no_index");
         $crate::configure_group(&mut no_index_group);
-        $crate::index::run_no_index_benchmarks(&mut no_index_group, $setup);
+        $crate::index::no_index::bench_vertex_insertion(&mut no_index_group, $setup.clone());
+        $crate::index::no_index::bench_edge_insertion(&mut no_index_group, $setup.clone());
+        $crate::index::no_index::bench_vertex_scan(&mut no_index_group, $setup.clone());
+        $crate::index::no_index::bench_vertex_removal(&mut no_index_group, $setup.clone());
+        $crate::index::no_index::bench_edge_removal(&mut no_index_group, $setup.clone());
         no_index_group.finish();
 
         // Run scaling benchmarks

--- a/graph-api-benches/src/mutation.rs
+++ b/graph-api-benches/src/mutation.rs
@@ -1,7 +1,9 @@
 use crate::generators::{GraphSize, generate_random_graph, generate_test_graph};
 
 use criterion::{BenchmarkGroup, Throughput, measurement::WallTime};
-use graph_api_lib::{EdgeSearch, Graph, VertexReferenceMut, VertexSearch};
+#[cfg(feature = "element-removal")]
+use graph_api_lib::SupportsElementRemoval;
+use graph_api_lib::{Graph, VertexReferenceMut, VertexSearch};
 use graph_api_test::{Edge, PersonMut, Vertex, VertexExt};
 
 /// Run all mutation operation benchmarks
@@ -11,6 +13,18 @@ pub fn run_benchmarks<G: Graph<Vertex = Vertex, Edge = Edge>>(
 ) {
     bench_mutation_vertex_update(group, setup.clone());
     bench_mutation_edge_add(group, setup.clone());
+
+    // Only run removal benchmarks if the feature is enabled and graph supports removal
+    #[cfg(feature = "element-removal")]
+    run_removal_benchmarks(group, setup);
+}
+
+/// Run removal-specific benchmarks
+#[cfg(feature = "element-removal")]
+fn run_removal_benchmarks<G: Graph<Vertex = Vertex, Edge = Edge> + SupportsElementRemoval>(
+    group: &mut BenchmarkGroup<WallTime>,
+    setup: impl Fn() -> G + Clone,
+) {
     bench_mutation_edge_remove(group, setup.clone());
 }
 
@@ -75,7 +89,8 @@ fn bench_mutation_edge_add<G: Graph<Vertex = Vertex, Edge = Edge>>(
 }
 
 /// Benchmark removing edges during traversal
-fn bench_mutation_edge_remove<G: Graph<Vertex = Vertex, Edge = Edge>>(
+#[cfg(feature = "element-removal")]
+fn bench_mutation_edge_remove<G: Graph<Vertex = Vertex, Edge = Edge> + SupportsElementRemoval>(
     group: &mut BenchmarkGroup<WallTime>,
     setup: impl Fn() -> G + Clone,
 ) {

--- a/graph-api-book/src/implementation/guide.md
+++ b/graph-api-book/src/implementation/guide.md
@@ -48,7 +48,7 @@ use graph_api_lib::{
     Graph, Element, EdgeSearch, VertexSearch,
     SupportsVertexLabelIndex, SupportsEdgeLabelIndex, SupportsVertexHashIndex,
     SupportsVertexRangeIndex, SupportsEdgeRangeIndex, SupportsVertexFullTextIndex,
-    SupportsEdgeAdjacentLabelIndex, SupportsClear
+    SupportsEdgeAdjacentLabelIndex, SupportsClear, SupportsElementRemoval
 };
 
 // Main graph structure
@@ -210,13 +210,6 @@ where
         // Implementation details
     }
 
-    fn remove_vertex(&mut self, id: Self::VertexId) -> Option<Self::Vertex> {
-        // Implementation details
-    }
-
-    fn remove_edge(&mut self, id: Self::EdgeId) -> Option<Self::Edge> {
-        // Implementation details
-    }
 
     fn vertex(&self, id: Self::VertexId) -> Option<Self::VertexReference<'_>> {
         // Implementation details
@@ -253,6 +246,23 @@ where
 }
 
 // Then implement support traits for the features you want to provide
+// Implement SupportsElementRemoval if you want to support removing vertices and edges
+impl<Vertex, Edge> SupportsElementRemoval for MyGraph<Vertex, Edge>
+where
+    Vertex: Element,
+    Edge: Element,
+{
+    fn remove_vertex(&mut self, id: Self::VertexId) -> Option<Self::Vertex> {
+        // Implementation details for removing a vertex
+        // Remember to handle connected edges and update indexes
+    }
+
+    fn remove_edge(&mut self, id: Self::EdgeId) -> Option<Self::Edge> {
+        // Implementation details for removing an edge
+        // Remember to update adjacency lists and indexes
+    }
+}
+
 impl<Vertex, Edge> SupportsVertexLabelIndex for MyGraph<Vertex, Edge>
 where
     Vertex: Element,

--- a/graph-api-lib/src/graph.rs
+++ b/graph-api-lib/src/graph.rs
@@ -114,12 +114,6 @@ pub trait Graph: Sized + Debug {
         edge: Self::Edge,
     ) -> Self::EdgeId;
 
-    /// Removes a vertex from the graph and returns the vertex.
-    fn remove_vertex(&mut self, id: Self::VertexId) -> Option<Self::Vertex>;
-
-    /// Removes an edge from the graph and returns the edge.
-    fn remove_edge(&mut self, id: Self::EdgeId) -> Option<Self::Edge>;
-
     /// Gets the vertex with the specified identifier.
     fn vertex(&self, id: Self::VertexId) -> Option<Self::VertexReference<'_>>;
 

--- a/graph-api-lib/src/petgraph/mod.rs
+++ b/graph-api-lib/src/petgraph/mod.rs
@@ -1,7 +1,7 @@
 use crate::graph::{EdgeReferenceMut, VertexReference, VertexReferenceMut};
 use crate::search::vertex::VertexSearch;
 use crate::{Direction, EdgeReference, Element, ElementId, Graph, Project, ProjectMut};
-use crate::{EdgeSearch, SupportsClear};
+use crate::{EdgeSearch, SupportsClear, SupportsElementRemoval};
 use petgraph::EdgeType;
 use petgraph::stable_graph::StableGraph;
 use petgraph::stable_graph::{EdgeIndex, Edges, IndexType};
@@ -61,14 +61,6 @@ where
         edge: Self::Edge,
     ) -> Self::EdgeId {
         petgraph::stable_graph::StableGraph::add_edge(self, from, to, edge)
-    }
-
-    fn remove_vertex(&mut self, vertex: Self::VertexId) -> Option<Self::Vertex> {
-        petgraph::stable_graph::StableGraph::remove_node(self, vertex)
-    }
-
-    fn remove_edge(&mut self, edge: Self::EdgeId) -> Option<Self::Edge> {
-        petgraph::stable_graph::StableGraph::remove_edge(self, edge)
     }
 
     fn vertex(&self, id: Self::VertexId) -> Option<Self::VertexReference<'_>> {
@@ -162,6 +154,22 @@ where
 {
     fn clear(&mut self) {
         petgraph::stable_graph::StableGraph::clear(self);
+    }
+}
+
+impl<Vertex, Edge, Ty, Ix> SupportsElementRemoval for StableGraph<Vertex, Edge, Ty, Ix>
+where
+    Ty: EdgeType,
+    Ix: IndexType,
+    Vertex: Element,
+    Edge: Element,
+{
+    fn remove_vertex(&mut self, vertex: Self::VertexId) -> Option<Self::Vertex> {
+        petgraph::stable_graph::StableGraph::remove_node(self, vertex)
+    }
+
+    fn remove_edge(&mut self, edge: Self::EdgeId) -> Option<Self::Edge> {
+        petgraph::stable_graph::StableGraph::remove_edge(self, edge)
     }
 }
 

--- a/graph-api-lib/src/support.rs
+++ b/graph-api-lib/src/support.rs
@@ -27,3 +27,12 @@ pub trait SupportsClear: crate::Graph {
     /// Clears the graph, removing all vertices and edges
     fn clear(&mut self);
 }
+
+/// Supports removal of individual vertices and edges
+pub trait SupportsElementRemoval: crate::Graph {
+    /// Removes a vertex from the graph and returns the vertex.
+    fn remove_vertex(&mut self, id: Self::VertexId) -> Option<Self::Vertex>;
+
+    /// Removes an edge from the graph and returns the edge.
+    fn remove_edge(&mut self, id: Self::EdgeId) -> Option<Self::Edge>;
+}

--- a/graph-api-simplegraph/src/index/mod.rs
+++ b/graph-api-simplegraph/src/index/mod.rs
@@ -68,7 +68,6 @@ impl<T: Index> From<&T> for VertexIndexStorage {
                 }
             };
         }
-
         index!(String, String);
         index!(Uuid, Uuid);
         index!(usize, USize);

--- a/graph-api-test/Cargo.toml
+++ b/graph-api-test/Cargo.toml
@@ -21,6 +21,7 @@ edge-label-index = []
 edge-index = []
 edge-range-index = []
 graph-clear = []
+element-removal = []
 
 
 [dependencies]

--- a/graph-api-test/src/graph/mod.rs
+++ b/graph-api-test/src/graph/mod.rs
@@ -1,4 +1,6 @@
 use crate::{Edge, Knows, KnowsMut, Person, PersonMut, Vertex, populate_graph};
+#[cfg(feature = "element-removal")]
+use graph_api_lib::SupportsElementRemoval;
 use graph_api_lib::{EdgeReference, EdgeReferenceMut, VertexReference, VertexReferenceMut};
 use uuid::Uuid;
 
@@ -16,9 +18,10 @@ where
     assert!(graph.vertex(vertex).is_some());
 }
 
+#[cfg(feature = "element-removal")]
 pub fn test_remove_vertex<Graph>(graph: &mut Graph)
 where
-    Graph: graph_api_lib::Graph<Vertex = Vertex, Edge = Edge>,
+    Graph: graph_api_lib::Graph<Vertex = Vertex, Edge = Edge> + SupportsElementRemoval,
 {
     let vertex = graph.add_vertex(Vertex::Person {
         name: "Bryn".to_string(),
@@ -29,6 +32,13 @@ where
     });
     graph.remove_vertex(vertex);
     assert!(graph.vertex(vertex).is_none());
+}
+
+#[cfg(not(feature = "element-removal"))]
+pub fn test_remove_vertex<Graph>(_graph: &mut Graph)
+where
+    Graph: graph_api_lib::Graph<Vertex = Vertex, Edge = Edge>,
+{
 }
 
 pub fn test_add_edge<Graph>(graph: &mut Graph)
@@ -53,9 +63,10 @@ where
     assert!(graph.edge(edge).is_some());
 }
 
+#[cfg(feature = "element-removal")]
 pub fn test_remove_edge<Graph>(graph: &mut Graph)
 where
-    Graph: graph_api_lib::Graph<Vertex = Vertex, Edge = Edge>,
+    Graph: graph_api_lib::Graph<Vertex = Vertex, Edge = Edge> + SupportsElementRemoval,
 {
     let v1 = graph.add_vertex(Vertex::Person {
         name: "Julia".to_string(),
@@ -76,9 +87,17 @@ where
     assert!(graph.edge(edge).is_none());
 }
 
-pub fn test_remove_vertex_with_edges<Graph>(graph: &mut Graph)
+#[cfg(not(feature = "element-removal"))]
+pub fn test_remove_edge<Graph>(_graph: &mut Graph)
 where
     Graph: graph_api_lib::Graph<Vertex = Vertex, Edge = Edge>,
+{
+}
+
+#[cfg(feature = "element-removal")]
+pub fn test_remove_vertex_with_edges<Graph>(graph: &mut Graph)
+where
+    Graph: graph_api_lib::Graph<Vertex = Vertex, Edge = Edge> + SupportsElementRemoval,
 {
     // Create vertices
     let v1 = graph.add_vertex(Vertex::Person {
@@ -120,6 +139,13 @@ where
     assert!(graph.vertex(v1).is_some());
     assert!(graph.vertex(v3).is_some());
     assert!(graph.edge(e3).is_some());
+}
+
+#[cfg(not(feature = "element-removal"))]
+pub fn test_remove_vertex_with_edges<Graph>(_graph: &mut Graph)
+where
+    Graph: graph_api_lib::Graph<Vertex = Vertex, Edge = Edge>,
+{
 }
 
 pub fn test_mutate_vertex<Graph>(graph: &mut Graph)

--- a/graph-api-test/src/index/edge_label.rs
+++ b/graph-api-test/src/index/edge_label.rs
@@ -1,9 +1,13 @@
-use crate::{Edge, Vertex, assert_elements_eq, populate_graph};
-use graph_api_lib::{Graph, SupportsEdgeLabelIndex};
+#[cfg(feature = "edge-label-index")]
+use crate::{assert_elements_eq, populate_graph};
 
+use crate::{Edge, Vertex};
+use graph_api_lib::Graph;
+
+#[cfg(feature = "edge-label-index")]
 pub fn test_index<T>(graph: &mut T)
 where
-    T: Graph<Vertex = Vertex, Edge = Edge> + SupportsEdgeLabelIndex,
+    T: Graph<Vertex = Vertex, Edge = Edge> + graph_api_lib::SupportsEdgeLabelIndex,
 {
     let refs = populate_graph(graph);
     let collected = graph
@@ -15,9 +19,17 @@ where
     assert_elements_eq!(graph, collected, vec![refs.bryn_knows_julia])
 }
 
+#[cfg(not(feature = "edge-label-index"))]
+pub fn test_index<T>(_graph: &mut T)
+where
+    T: Graph<Vertex = Vertex, Edge = Edge>,
+{
+}
+
+#[cfg(feature = "edge-label-index")]
 pub fn test_index_limit<T>(graph: &mut T)
 where
-    T: Graph<Vertex = Vertex, Edge = Edge> + SupportsEdgeLabelIndex,
+    T: Graph<Vertex = Vertex, Edge = Edge> + graph_api_lib::SupportsEdgeLabelIndex,
 {
     let refs = populate_graph(graph);
     let collected = graph
@@ -27,4 +39,11 @@ where
         .collect::<Vec<_>>();
 
     assert_elements_eq!(graph, collected, vec![refs.bryn_knows_julia])
+}
+
+#[cfg(not(feature = "edge-label-index"))]
+pub fn test_index_limit<T>(_graph: &mut T)
+where
+    T: Graph<Vertex = Vertex, Edge = Edge>,
+{
 }

--- a/graph-api-test/src/index/vertex_full_text.rs
+++ b/graph-api-test/src/index/vertex_full_text.rs
@@ -1,5 +1,10 @@
-use crate::{Edge, PersonMut, Vertex, assert_elements_eq, populate_graph};
-use graph_api_lib::{Graph, SupportsVertexFullTextIndex, VertexReferenceMut};
+#[cfg(feature = "vertex-full-text-index")]
+use crate::{PersonMut, assert_elements_eq, populate_graph};
+#[cfg(feature = "vertex-full-text-index")]
+use graph_api_lib::VertexReferenceMut;
+
+use crate::{Edge, Vertex};
+use graph_api_lib::Graph;
 
 /// Tests that a vertex can be added to the graph and that the indexed field
 /// search returns the added vertex.
@@ -7,9 +12,10 @@ use graph_api_lib::{Graph, SupportsVertexFullTextIndex, VertexReferenceMut};
 /// This function creates a vertex, adds it to the graph, and then verifies
 /// that a search for the indexed field of the added vertex returns the
 /// expected result.
+#[cfg(feature = "vertex-full-text-index")]
 pub fn test_index<T>(graph: &mut T)
 where
-    T: Graph<Vertex = Vertex, Edge = Edge> + SupportsVertexFullTextIndex,
+    T: Graph<Vertex = Vertex, Edge = Edge> + graph_api_lib::SupportsVertexFullTextIndex,
 {
     let refs = populate_graph(graph);
     let collected = graph
@@ -17,7 +23,12 @@ where
         .vertices(Vertex::person_by_biography("graph"))
         .collect::<Vec<_>>();
     assert_elements_eq!(graph, collected, vec![refs.bryn]);
-    graph.remove_vertex(refs.bryn);
+}
+#[cfg(not(feature = "vertex-full-text-index"))]
+pub fn test_index<T>(_graph: &mut T)
+where
+    T: Graph<Vertex = Vertex, Edge = Edge>,
+{
 }
 
 /// Tests that a vertex can be removed from the graph, and that the indexed field
@@ -26,9 +37,12 @@ where
 /// This function creates a vertex, adds it to the graph, and then removes it.
 /// It then verifies that a search for the indexed field of the removed vertex
 /// returns an empty result.
+#[cfg(all(feature = "vertex-full-text-index", feature = "element-removal"))]
 pub fn test_index_remove<T>(graph: &mut T)
 where
-    T: Graph<Vertex = Vertex, Edge = Edge> + SupportsVertexFullTextIndex,
+    T: Graph<Vertex = Vertex, Edge = Edge>
+        + graph_api_lib::SupportsVertexFullTextIndex
+        + graph_api_lib::SupportsElementRemoval,
 {
     let refs = populate_graph(graph);
     graph.remove_vertex(refs.bryn);
@@ -41,6 +55,13 @@ where
     );
 }
 
+#[cfg(not(all(feature = "vertex-full-text-index", feature = "element-removal")))]
+pub fn test_index_remove<T>(_graph: &mut T)
+where
+    T: Graph<Vertex = Vertex, Edge = Edge>,
+{
+}
+
 /// Tests that a vertex's indexed field can be updated and that the graph's
 /// search functionality reflects this change.
 ///
@@ -50,9 +71,10 @@ where
 /// - The old value of the indexed field is no longer present in the graph
 /// - The new value of the indexed field is correctly associated
 ///   with the updated vertex
+#[cfg(feature = "vertex-full-text-index")]
 pub fn test_index_update<T>(graph: &mut T)
 where
-    T: Graph<Vertex = Vertex, Edge = Edge> + SupportsVertexFullTextIndex,
+    T: Graph<Vertex = Vertex, Edge = Edge> + graph_api_lib::SupportsVertexFullTextIndex,
 {
     let refs = populate_graph(graph);
     graph
@@ -75,4 +97,11 @@ where
             .count(),
         1
     );
+}
+
+#[cfg(not(feature = "vertex-full-text-index"))]
+pub fn test_index_update<T>(_graph: &mut T)
+where
+    T: Graph<Vertex = Vertex, Edge = Edge>,
+{
 }

--- a/graph-api-test/src/index/vertex_hash.rs
+++ b/graph-api-test/src/index/vertex_hash.rs
@@ -1,5 +1,10 @@
-use crate::{Edge, PersonMut, Vertex, assert_elements_eq, populate_graph};
-use graph_api_lib::{Graph, SupportsVertexHashIndex, VertexReferenceMut};
+#[cfg(feature = "vertex-hash-index")]
+use crate::{PersonMut, assert_elements_eq, populate_graph};
+#[cfg(feature = "vertex-hash-index")]
+use graph_api_lib::VertexReferenceMut;
+
+use crate::{Edge, Vertex};
+use graph_api_lib::Graph;
 
 /// Tests that a vertex can be added to the graph and that the indexed field
 /// search returns the added vertex.
@@ -7,9 +12,10 @@ use graph_api_lib::{Graph, SupportsVertexHashIndex, VertexReferenceMut};
 /// This function creates a vertex, adds it to the graph, and then verifies
 /// that a search for the indexed field of the added vertex returns the
 /// expected result.
+#[cfg(feature = "vertex-hash-index")]
 pub fn test_index<T>(graph: &mut T)
 where
-    T: Graph<Vertex = Vertex, Edge = Edge> + SupportsVertexHashIndex,
+    T: Graph<Vertex = Vertex, Edge = Edge> + graph_api_lib::SupportsVertexHashIndex,
 {
     let refs = populate_graph(graph);
     let collected = graph
@@ -17,18 +23,26 @@ where
         .vertices(Vertex::person_by_name("Bryn"))
         .collect::<Vec<_>>();
     assert_elements_eq!(graph, collected, vec![refs.bryn]);
-    graph.remove_vertex(refs.bryn);
 }
 
+#[cfg(not(feature = "vertex-hash-index"))]
+pub fn test_index<T>(_graph: &mut T)
+where
+    T: Graph<Vertex = Vertex, Edge = Edge>,
+{
+}
 /// Tests that a vertex can be removed from the graph, and that the indexed field
 /// search no longer returns the removed vertex.
 ///
 /// This function creates a vertex, adds it to the graph, and then removes it.
 /// It then verifies that a search for the indexed field of the removed vertex
 /// returns an empty result.
+#[cfg(all(feature = "vertex-hash-index", feature = "element-removal"))]
 pub fn test_index_remove<T>(graph: &mut T)
 where
-    T: Graph<Vertex = Vertex, Edge = Edge> + SupportsVertexHashIndex,
+    T: Graph<Vertex = Vertex, Edge = Edge>
+        + graph_api_lib::SupportsVertexHashIndex
+        + graph_api_lib::SupportsElementRemoval,
 {
     let refs = populate_graph(graph);
     graph.remove_vertex(refs.bryn);
@@ -41,9 +55,17 @@ where
     );
 }
 
+#[cfg(not(all(feature = "vertex-hash-index", feature = "element-removal")))]
+pub fn test_index_remove<T>(_graph: &mut T)
+where
+    T: Graph<Vertex = Vertex, Edge = Edge>,
+{
+}
+
+#[cfg(feature = "vertex-hash-index")]
 pub fn test_index_update<T>(graph: &mut T)
 where
-    T: Graph<Vertex = Vertex, Edge = Edge> + SupportsVertexHashIndex,
+    T: Graph<Vertex = Vertex, Edge = Edge> + graph_api_lib::SupportsVertexHashIndex,
 {
     let refs = populate_graph(graph);
     graph
@@ -66,4 +88,11 @@ where
             .count(),
         1
     );
+}
+
+#[cfg(not(feature = "vertex-hash-index"))]
+pub fn test_index_update<T>(_graph: &mut T)
+where
+    T: Graph<Vertex = Vertex, Edge = Edge>,
+{
 }

--- a/graph-api-test/src/index/vertex_label.rs
+++ b/graph-api-test/src/index/vertex_label.rs
@@ -1,18 +1,30 @@
-use crate::{Edge, Vertex, assert_elements_eq, populate_graph};
-use graph_api_lib::{Graph, SupportsVertexLabelIndex};
+#[cfg(feature = "vertex-label-index")]
+use crate::{assert_elements_eq, populate_graph};
 
+use crate::{Edge, Vertex};
+use graph_api_lib::Graph;
+
+#[cfg(feature = "vertex-label-index")]
 pub fn test_index<T>(graph: &mut T)
 where
-    T: Graph<Vertex = Vertex, Edge = Edge> + SupportsVertexLabelIndex,
+    T: Graph<Vertex = Vertex, Edge = Edge> + graph_api_lib::SupportsVertexLabelIndex,
 {
     let refs = populate_graph(graph);
     let collected = graph.walk().vertices(Vertex::person()).collect::<Vec<_>>();
     assert_elements_eq!(graph, collected, vec![refs.bryn, refs.julia]);
 }
 
+#[cfg(not(feature = "vertex-label-index"))]
+pub fn test_index<T>(_graph: &mut T)
+where
+    T: Graph<Vertex = Vertex, Edge = Edge>,
+{
+}
+
+#[cfg(feature = "vertex-label-index")]
 pub fn test_index_limit<T>(graph: &mut T)
 where
-    T: Graph<Vertex = Vertex, Edge = Edge> + SupportsVertexLabelIndex,
+    T: Graph<Vertex = Vertex, Edge = Edge> + graph_api_lib::SupportsVertexLabelIndex,
 {
     let refs = populate_graph(graph);
     let collected = graph
@@ -20,4 +32,11 @@ where
         .vertices(Vertex::person().with_limit(1))
         .collect::<Vec<_>>();
     assert_elements_eq!(graph, collected, vec![refs.bryn]);
+}
+
+#[cfg(not(feature = "vertex-label-index"))]
+pub fn test_index_limit<T>(_graph: &mut T)
+where
+    T: Graph<Vertex = Vertex, Edge = Edge>,
+{
 }

--- a/graph-api-test/src/index/vertex_range.rs
+++ b/graph-api-test/src/index/vertex_range.rs
@@ -1,9 +1,15 @@
-use crate::{Edge, PersonMut, Vertex, assert_elements_eq, populate_graph};
-use graph_api_lib::{Graph, SupportsVertexHashIndex, SupportsVertexRangeIndex, VertexReferenceMut};
+#[cfg(feature = "vertex-range-index")]
+use crate::{PersonMut, assert_elements_eq, populate_graph};
+#[cfg(feature = "vertex-range-index")]
+use graph_api_lib::VertexReferenceMut;
 
+use crate::{Edge, Vertex};
+use graph_api_lib::Graph;
+
+#[cfg(feature = "vertex-range-index")]
 pub fn test_index<T>(graph: &mut T)
 where
-    T: Graph<Vertex = Vertex, Edge = Edge> + SupportsVertexRangeIndex + SupportsVertexHashIndex,
+    T: Graph<Vertex = Vertex, Edge = Edge> + graph_api_lib::SupportsVertexRangeIndex,
 {
     let refs = populate_graph(graph);
     // Test range query for age between 20-40
@@ -12,17 +18,21 @@ where
         .vertices(Vertex::person_by_age_range(20..46))
         .collect::<Vec<_>>();
     assert_elements_eq!(graph, collected, vec![refs.bryn]);
-
-    let collected = graph
-        .walk()
-        .vertices(Vertex::person_by_age(45))
-        .collect::<Vec<_>>();
-    assert_elements_eq!(graph, collected, vec![refs.bryn]);
 }
 
+#[cfg(not(feature = "vertex-range-index"))]
+pub fn test_index<T>(_graph: &mut T)
+where
+    T: Graph<Vertex = Vertex, Edge = Edge>,
+{
+}
+
+#[cfg(all(feature = "vertex-range-index", feature = "element-removal"))]
 pub fn test_index_remove<T>(graph: &mut T)
 where
-    T: Graph<Vertex = Vertex, Edge = Edge> + SupportsVertexRangeIndex,
+    T: Graph<Vertex = Vertex, Edge = Edge>
+        + graph_api_lib::SupportsVertexRangeIndex
+        + graph_api_lib::SupportsElementRemoval,
 {
     let refs = populate_graph(graph);
     // Remove a vertex
@@ -38,9 +48,17 @@ where
     );
 }
 
+#[cfg(not(all(feature = "element-removal", feature = "vertex-range-index")))]
+pub fn test_index_remove<T>(_graph: &mut T)
+where
+    T: Graph<Vertex = Vertex, Edge = Edge>,
+{
+}
+
+#[cfg(feature = "vertex-range-index")]
 pub fn test_index_update<T>(graph: &mut T)
 where
-    T: Graph<Vertex = Vertex, Edge = Edge> + SupportsVertexRangeIndex,
+    T: Graph<Vertex = Vertex, Edge = Edge> + graph_api_lib::SupportsVertexRangeIndex,
 {
     let refs = populate_graph(graph);
     graph
@@ -62,4 +80,11 @@ where
         .vertices(Vertex::person_by_age_range(100..106))
         .collect::<Vec<_>>();
     assert_elements_eq!(graph, collected, vec![refs.bryn]);
+}
+
+#[cfg(not(feature = "vertex-range-index"))]
+pub fn test_index_update<T>(_graph: &mut T)
+where
+    T: Graph<Vertex = Vertex, Edge = Edge>,
+{
 }

--- a/graph-api-test/src/lib.rs
+++ b/graph-api-test/src/lib.rs
@@ -127,20 +127,6 @@ pub enum TestError {
 }
 
 #[macro_export]
-macro_rules! check_unsupported {
-    ($setup:expr, $name:ident, $feature:path) => {
-        #[test]
-        #[ignore] // Ignoring these tests since we can't check for !Trait
-        fn $name() {
-            fn check(g: impl graph_api_lib::Graph<Vertex = (), Edge = ()>) {}
-            // For now, we just verify the graph can be created
-            let g = $setup;
-            check(g);
-        }
-    };
-}
-
-#[macro_export]
 macro_rules! general_test {
     ($setup:expr, $name:ident, $path:path) => {
         #[test]
@@ -151,107 +137,10 @@ macro_rules! general_test {
     };
 }
 
-#[cfg(feature = "edge-label-index")]
-#[macro_export]
-macro_rules! edge_index_label_test {
-    ($setup:expr, $name:ident, $path:path) => {
-        #[test]
-        fn $name() {
-            let mut g = $setup;
-            $path(&mut g);
-        }
-    };
-}
-#[cfg(not(feature = "edge-label-index"))]
-#[macro_export]
-macro_rules! edge_index_label_test {
-    ($setup:expr, $name:ident, $path:path) => {
-        $crate::check_unsupported!($setup, $name, SupportsEdgeLabelIndex);
-    };
-}
-
-#[cfg(feature = "vertex-label-index")]
-#[macro_export]
-macro_rules! vertex_index_label_test {
-    ($setup:expr, $name:ident, $path:path) => {
-        #[test]
-        fn $name() {
-            let mut g = $setup;
-            $path(&mut g);
-        }
-    };
-}
-
-#[cfg(not(feature = "vertex-label-index"))]
-#[macro_export]
-macro_rules! vertex_index_label_test {
-    ($setup:expr, $name:ident, $path:path) => {
-        $crate::check_unsupported!($setup, $name, SupportsVertexLabelIndex);
-    };
-}
-
-#[cfg(feature = "vertex-hash-index")]
-#[macro_export]
-macro_rules! vertex_index_hash_test {
-    ($setup:expr, $name:ident, $path:path) => {
-        #[test]
-        fn $name() {
-            let mut g = $setup;
-            $path(&mut g);
-        }
-    };
-}
-#[cfg(not(feature = "vertex-hash-index"))]
-#[macro_export]
-macro_rules! vertex_index_hash_test {
-    ($setup:expr, $name:ident, $path:path) => {
-        $crate::check_unsupported!($setup, $name, SupportsVertexHashIndex);
-    };
-}
-
-#[cfg(feature = "vertex-full-text-index")]
-#[macro_export]
-macro_rules! vertex_index_full_text_test {
-    ($setup:expr, $name:ident, $path:path) => {
-        #[test]
-        fn $name() {
-            let mut g = $setup;
-            $path(&mut g);
-        }
-    };
-}
-#[cfg(not(feature = "vertex-full-text-index"))]
-#[macro_export]
-macro_rules! vertex_index_full_text_test {
-    ($setup:expr, $name:ident, $path:path) => {
-        $crate::check_unsupported!($setup, $name, SupportsVertexFullTextIndex);
-    };
-}
-
-#[cfg(feature = "vertex-range-index")]
-#[macro_export]
-macro_rules! vertex_index_range_test {
-    ($setup:expr, $name:ident, $path:path) => {
-        #[test]
-        fn $name() {
-            let mut g = $setup;
-            $path(&mut g);
-        }
-    };
-}
-
-#[cfg(not(feature = "vertex-range-index"))]
-#[macro_export]
-macro_rules! vertex_index_range_test {
-    ($setup:expr, $name:ident, $path:path) => {
-        $crate::check_unsupported!($setup, $name, SupportsVertexRangeIndex);
-    };
-}
-
 #[macro_export]
 macro_rules! test_suite {
     ($setup:expr) => {
-        $crate::general_test! {$setup, graph_test_add_vertex, $crate::graph::test_add_vertex}
+        $crate::general_test!{$setup, graph_test_add_vertex, $crate::graph::test_add_vertex}
         $crate::general_test!{$setup, graph_test_mutate_vertex, $crate::graph::test_mutate_vertex}
         $crate::general_test!{$setup, graph_test_remove_vertex, $crate::graph::test_remove_vertex}
         $crate::general_test!{$setup, graph_test_add_edge, $crate::graph::test_add_edge}
@@ -299,19 +188,19 @@ macro_rules! test_suite {
         $crate::general_test!{$setup, probe_test_edges_probe, $crate::steps::probe::test_edges_probe}
         $crate::general_test!{$setup, control_flow_test_vertices_control_flow, $crate::steps::control_flow::test_vertices_control_flow}
         $crate::general_test!{$setup, control_flow_test_edges_control_flow, $crate::steps::control_flow::test_edges_control_flow}
-        $crate::edge_index_label_test!{$setup, index_edge_label_test_index, $crate::index::edge_label::test_index}
-        $crate::edge_index_label_test!{$setup, index_edge_label_test_index_limit, $crate::index::edge_label::test_index_limit}
-        $crate::vertex_index_label_test!{$setup, index_vertex_label_test_index, $crate::index::vertex_label::test_index}
-        $crate::vertex_index_label_test!{$setup, index_vertex_label_test_index_limit, $crate::index::vertex_label::test_index_limit}
-        $crate::vertex_index_hash_test!{$setup, index_vertex_hash_test_index, $crate::index::vertex_hash::test_index}
-        $crate::vertex_index_hash_test!{$setup, index_vertex_hash_test_index_remove, $crate::index::vertex_hash::test_index_remove}
-        $crate::vertex_index_hash_test!{$setup, index_vertex_hash_test_index_update, $crate::index::vertex_hash::test_index_update}
-        $crate::vertex_index_full_text_test!{$setup, index_vertex_full_text_test_index, $crate::index::vertex_full_text::test_index}
-        $crate::vertex_index_full_text_test!{$setup, index_vertex_full_text_test_index_remove, $crate::index::vertex_full_text::test_index_remove}
-        $crate::vertex_index_full_text_test!{$setup, index_vertex_full_text_test_index_update, $crate::index::vertex_full_text::test_index_update}
-        $crate::vertex_index_range_test!{$setup, index_vertex_range_test_index, $crate::index::vertex_range::test_index}
-        $crate::vertex_index_range_test!{$setup, index_vertex_range_test_index_remove, $crate::index::vertex_range::test_index_remove}
-        $crate::vertex_index_range_test!{$setup, index_vertex_range_test_index_update, $crate::index::vertex_range::test_index_update}
+        $crate::general_test!{$setup, index_edge_label_test_index, $crate::index::edge_label::test_index}
+        $crate::general_test!{$setup, index_edge_label_test_index_limit, $crate::index::edge_label::test_index_limit}
+        $crate::general_test!{$setup, index_vertex_label_test_index, $crate::index::vertex_label::test_index}
+        $crate::general_test!{$setup, index_vertex_label_test_index_limit, $crate::index::vertex_label::test_index_limit}
+        $crate::general_test!{$setup, index_vertex_hash_test_index, $crate::index::vertex_hash::test_index}
+        $crate::general_test!{$setup, index_vertex_hash_test_index_remove, $crate::index::vertex_hash::test_index_remove}
+        $crate::general_test!{$setup, index_vertex_hash_test_index_update, $crate::index::vertex_hash::test_index_update}
+        $crate::general_test!{$setup, index_vertex_full_text_test_index, $crate::index::vertex_full_text::test_index}
+        $crate::general_test!{$setup, index_vertex_full_text_test_index_remove, $crate::index::vertex_full_text::test_index_remove}
+        $crate::general_test!{$setup, index_vertex_full_text_test_index_update, $crate::index::vertex_full_text::test_index_update}
+        $crate::general_test!{$setup, index_vertex_range_test_index, $crate::index::vertex_range::test_index}
+        $crate::general_test!{$setup, index_vertex_range_test_index_remove, $crate::index::vertex_range::test_index_remove}
+        $crate::general_test!{$setup, index_vertex_range_test_index_update, $crate::index::vertex_range::test_index_update}
 
         $crate::proptest! {
             #[test]


### PR DESCRIPTION
Eleement removal is now moved to `SupportsElementRemoval` trait.
Not all graphs support removal of elements, and removal support brings as significant amount of extra complexity and potential overhead for implementors.

Fixes #66 