### PR TITLE
fix: VertexLabel names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,6 +439,7 @@ dependencies = [
  "serde",
  "syn 2.0.100",
  "trybuild",
+ "uuid",
 ]
 
 [[package]]

--- a/graph-api-derive/Cargo.toml
+++ b/graph-api-derive/Cargo.toml
@@ -20,6 +20,7 @@ quote = "1.0"
 proc-macro2 = "1.0.82"
 serde = { version = "1.0.202", features = ["derive"] }
 case = "1.0.0"
+uuid = { version = "1.16.0", features = ["v4"] }
 
 [dev-dependencies]
 insta = { version = "1.39.0", features = ["yaml"] }

--- a/graph-api-derive/src/render.rs
+++ b/graph-api-derive/src/render.rs
@@ -282,7 +282,7 @@ impl Model {
 
                 fn name(&self) -> &'static str {
                     match self {
-                        #(#label_ident::#labels => "#labels"),*
+                        #(#label_ident::#labels => stringify!(#labels)),*
                     }
                 }
             }

--- a/graph-api-derive/src/snapshots/graph_api_derive__render__tests__render_edge.snap
+++ b/graph-api-derive/src/snapshots/graph_api_derive__render__tests__render_edge.snap
@@ -39,9 +39,9 @@ impl graph_api_lib::Label for EdgeLabel {
     }
     fn name(&self) -> &'static str {
         match self {
-            EdgeLabel::Knows => "#labels",
-            EdgeLabel::Created => "#labels",
-            EdgeLabel::Language => "#labels",
+            EdgeLabel::Knows => stringify!(Knows),
+            EdgeLabel::Created => stringify!(Created),
+            EdgeLabel::Language => stringify!(Language),
         }
     }
 }

--- a/graph-api-derive/src/snapshots/graph_api_derive__render__tests__render_vertex.snap
+++ b/graph-api-derive/src/snapshots/graph_api_derive__render__tests__render_vertex.snap
@@ -45,9 +45,9 @@ impl graph_api_lib::Label for VertexLabel {
     }
     fn name(&self) -> &'static str {
         match self {
-            VertexLabel::Person => "#labels",
-            VertexLabel::Project => "#labels",
-            VertexLabel::Rust => "#labels",
+            VertexLabel::Person => stringify!(Person),
+            VertexLabel::Project => stringify!(Project),
+            VertexLabel::Rust => stringify!(Rust),
         }
     }
 }

--- a/graph-api-derive/tests/test.rs
+++ b/graph-api-derive/tests/test.rs
@@ -1,0 +1,53 @@
+use graph_api_derive::{EdgeExt, VertexExt};
+use graph_api_lib::{Element, Label};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, VertexExt)]
+pub enum Vertex {
+    Person {
+        #[index(hash)]
+        name: String,
+        #[index(range)]
+        age: u64,
+        #[index(hash)]
+        unique_id: Uuid,
+        #[index(range)]
+        username: String,
+        #[index(full_text)]
+        biography: String,
+    },
+    Project(Project),
+    Rust,
+}
+
+#[derive(Debug, Clone)]
+pub struct Project {
+    pub name: String,
+}
+
+#[derive(Debug, Clone, EdgeExt)]
+pub enum Edge {
+    Knows { since: i32 },
+    Created,
+    Language(Language),
+}
+#[derive(Debug, Clone)]
+pub struct Language {
+    pub name: String,
+}
+
+#[test]
+fn test_label_name() {
+    assert_eq!(
+        Vertex::Person {
+            name: "".to_string(),
+            age: 0,
+            unique_id: Default::default(),
+            username: "".to_string(),
+            biography: "".to_string(),
+        }
+        .label()
+        .name(),
+        "Person"
+    );
+}


### PR DESCRIPTION
Previously these were all `#label` due to faulty macro rendering.