### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,18 +124,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.36"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.36"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -406,7 +406,7 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "graph-api-benches"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "criterion",
  "graph-api-derive",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "graph-api-derive"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "case",
  "graph-api-lib",
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "graph-api-lib"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "derivative",
  "graph-api-simplegraph",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "graph-api-petgraph"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "criterion",
  "graph-api-benches",
@@ -468,7 +468,7 @@ dependencies = [
 
 [[package]]
 name = "graph-api-simplegraph"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "criterion",
  "fastbloom",
@@ -484,7 +484,7 @@ dependencies = [
 
 [[package]]
 name = "graph-api-test"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "graph-api-derive",
  "graph-api-lib",

--- a/graph-api-benches/CHANGELOG.md
+++ b/graph-api-benches/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2025-04-20
+
+### 🚀 Features
+
+- [**breaking**] Move removal of elements to a supports trait (#76)
+
+
 ## [0.1.6] - 2025-04-17
 
 ### ⚙️ Miscellaneous Tasks

--- a/graph-api-benches/Cargo.toml
+++ b/graph-api-benches/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-api-benches"
-version = "0.1.6"
+version = "0.2.0"
 edition = "2024"
 description = "Benchmarking utilities and performance tests for the graph-api ecosystem"
 authors = ["Bryn Cooke"]
@@ -28,12 +28,12 @@ bench = false
 
 
 [dependencies]
-graph-api-lib = { version = "0.1.4", path = "../graph-api-lib" }
-graph-api-derive = { version = "0.1.3", path = "../graph-api-derive" }
+graph-api-lib = { version = "0.2.0", path = "../graph-api-lib" }
+graph-api-derive = { version = "0.1.4", path = "../graph-api-derive" }
 uuid = { version = "1.11.0", features = ["v4"] }
 criterion = { version = "0.5", features = ["html_reports"] }
 rand = { version = "0.9" }
-graph-api-test = { version = "0.1.6", path = "../graph-api-test" }
+graph-api-test = { version = "0.2.0", path = "../graph-api-test" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/graph-api-book/book.toml
+++ b/graph-api-book/book.toml
@@ -13,10 +13,10 @@ git-repository-icon = "fa-github"
 [output.linkcheck]
 
 [preprocessor.variables.variables]
-version = "0.1.4"  # Legacy variable - will be removed once all md files are updated
-lib_version = "0.1.4"
-derive_version = "0.1.3"
-simplegraph_version = "0.1.4"
-petgraph_version = "0.1.4"
-test_version = "0.1.6"
-benches_version = "0.1.6"
+version = "0.2.0"  # Legacy variable - will be removed once all md files are updated
+lib_version = "0.2.0"
+derive_version = "0.1.4"
+simplegraph_version = "0.2.0"
+petgraph_version = "0.1.5"
+test_version = "0.2.0"
+benches_version = "0.2.0"

--- a/graph-api-derive/CHANGELOG.md
+++ b/graph-api-derive/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.4] - 2025-04-20
+
+### 🐛 Bug Fixes
+
+- VertexLabel names (#79)
+- VertexLabel index types (#81)
+
+
 ## [0.1.3] - 2025-04-17
 
 ### 🐛 Bug Fixes

--- a/graph-api-derive/Cargo.toml
+++ b/graph-api-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-api-derive"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "Derive macros for the graph-api ecosystem - provides type-safe vertex and edge extensions"
 authors = ["Bryn Cooke"]

--- a/graph-api-lib/CHANGELOG.md
+++ b/graph-api-lib/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2025-04-20
+
+### 🚀 Features
+
+- [**breaking**] Move removal of elements to a supports trait (#76)
+
+
 ## [0.1.4] - 2025-04-13
 
 ### ⚙️ Miscellaneous Tasks

--- a/graph-api-lib/Cargo.toml
+++ b/graph-api-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-api-lib"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2024"
 description = "Core library for the graph-api ecosystem - a flexible, type-safe API for working with in-memory graphs in Rust"
 authors = ["Bryn Cooke"]

--- a/graph-api-petgraph/CHANGELOG.md
+++ b/graph-api-petgraph/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.5] - 2025-04-20
+
+### ⚙️ Miscellaneous Tasks
+
+- Updated the following local packages: graph-api-lib
+
+
 ## [0.1.4] - 2025-04-13
 
 ### ⚙️ Miscellaneous Tasks

--- a/graph-api-petgraph/Cargo.toml
+++ b/graph-api-petgraph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-api-petgraph"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 description = "Integration between graph-api and petgraph - use graph-api's traversal system with petgraph structures"
 authors = ["Bryn Cooke"]
@@ -15,7 +15,7 @@ categories = ["data-structures", "algorithms"]
 bench = false
 
 [dependencies]
-graph-api-lib = { version = "0.1.4", path = "../graph-api-lib", features = ["petgraph"] }
+graph-api-lib = { version = "0.2.0", path = "../graph-api-lib", features = ["petgraph"] }
 petgraph = { workspace = true }
 
 [dev-dependencies]

--- a/graph-api-simplegraph/CHANGELOG.md
+++ b/graph-api-simplegraph/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2025-04-20
+
+### 🚀 Features
+
+- [**breaking**] Move removal of elements to a supports trait (#76)
+
+
 ## [0.1.4] - 2025-04-13
 
 ### ⚙️ Miscellaneous Tasks

--- a/graph-api-simplegraph/Cargo.toml
+++ b/graph-api-simplegraph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-api-simplegraph"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2024"
 description = "A simple, efficient graph implementation for the graph-api ecosystem with support for indexing"
 authors = ["Bryn Cooke"]
@@ -16,7 +16,7 @@ categories = ["data-structures", "memory-management"]
 bench = false
 
 [dependencies]
-graph-api-lib = { version = "0.1.4", path = "../graph-api-lib" }
+graph-api-lib = { version = "0.2.0", path = "../graph-api-lib" }
 paste = "1.0.15"
 fastbloom = "0.9.0"
 rphonetic = "3.0.1"

--- a/graph-api-test/CHANGELOG.md
+++ b/graph-api-test/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2025-04-20
+
+### 🚀 Features
+
+- [**breaking**] Move removal of elements to a supports trait (#76)
+
+
 ## [0.1.6] - 2025-04-17
 
 ### ⚙️ Miscellaneous Tasks

--- a/graph-api-test/Cargo.toml
+++ b/graph-api-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-api-test"
-version = "0.1.6"
+version = "0.2.0"
 edition = "2024"
 description = "Test utilities and property-based testing for the graph-api ecosystem"
 authors = ["Bryn Cooke"]
@@ -25,8 +25,8 @@ element-removal = []
 
 
 [dependencies]
-graph-api-lib = { version = "0.1.4", path = "../graph-api-lib" }
-graph-api-derive = { version = "0.1.3", path = "../graph-api-derive" }
+graph-api-lib = { version = "0.2.0", path = "../graph-api-lib" }
+graph-api-derive = { version = "0.1.4", path = "../graph-api-derive" }
 thiserror = "2.0.3"
 proptest = "1.5.0"
 uuid = { version = "1.11.0", features = ["v4"] }


### PR DESCRIPTION



## 🤖 New release

* `graph-api-lib`: 0.1.4 -> 0.2.0 (⚠ API breaking changes)
* `graph-api-simplegraph`: 0.1.4 -> 0.2.0 (✓ API compatible changes)
* `graph-api-derive`: 0.1.3 -> 0.1.4
* `graph-api-test`: 0.1.6 -> 0.2.0 (⚠ API breaking changes)
* `graph-api-benches`: 0.1.6 -> 0.2.0 (⚠ API breaking changes)
* `graph-api-petgraph`: 0.1.4 -> 0.1.5

### ⚠ `graph-api-lib` breaking changes

```text
--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/trait_method_missing.ron

Failed in:
  method remove_vertex of trait Graph, previously in file /tmp/.tmp3Uy9nq/graph-api-lib/src/graph.rs:118
  method remove_edge of trait Graph, previously in file /tmp/.tmp3Uy9nq/graph-api-lib/src/graph.rs:121
```

### ⚠ `graph-api-test` breaking changes

```text
--- failure declarative_macro_missing: macro_rules declaration removed or renamed ---

Description:
A `macro_rules!` declarative macro cannot be invoked by its prior name. The macro may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/reference/macros-by-example.html#path-based-scope
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/declarative_macro_missing.ron

Failed in:
  macro vertex_index_range_test, previously in file /tmp/.tmp3Uy9nq/graph-api-test/src/lib.rs:233
  macro vertex_index_hash_test, previously in file /tmp/.tmp3Uy9nq/graph-api-test/src/lib.rs:195
  macro edge_index_label_test, previously in file /tmp/.tmp3Uy9nq/graph-api-test/src/lib.rs:156
  macro check_unsupported, previously in file /tmp/.tmp3Uy9nq/graph-api-test/src/lib.rs:130
  macro vertex_index_full_text_test, previously in file /tmp/.tmp3Uy9nq/graph-api-test/src/lib.rs:214
  macro vertex_index_label_test, previously in file /tmp/.tmp3Uy9nq/graph-api-test/src/lib.rs:175

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_variant_added.ron

Failed in:
  variant GraphOperation:Noop in /tmp/.tmpFOTm41/graph-api/graph-api-test/src/fuzz.rs:13
```

### ⚠ `graph-api-benches` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant VertexIndex::ProjectName 2 -> 1 in /tmp/.tmpFOTm41/graph-api/graph-api-benches/src/index/vertex_hash/mod.rs:21

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_variant_missing.ron

Failed in:
  variant VertexIndex::PersonUniqueId, previously in file /tmp/.tmp3Uy9nq/graph-api-benches/src/index/vertex_hash/mod.rs:11
  variant VertexIndex::PersonUsername, previously in file /tmp/.tmp3Uy9nq/graph-api-benches/src/index/vertex_range/mod.rs:10

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/function_missing.ron

Failed in:
  function graph_api_benches::index::no_index::run_benchmarks, previously in file /tmp/.tmp3Uy9nq/graph-api-benches/src/index/no_index/mod.rs:54
  function graph_api_benches::index::run_no_index_benchmarks, previously in file /tmp/.tmp3Uy9nq/graph-api-benches/src/index/no_index/mod.rs:54
  function graph_api_benches::index::edge_label::run_benchmarks, previously in file /tmp/.tmp3Uy9nq/graph-api-benches/src/index/edge_label/mod.rs:92
  function graph_api_benches::index::run_edge_label_benchmarks, previously in file /tmp/.tmp3Uy9nq/graph-api-benches/src/index/edge_label/mod.rs:92
  function graph_api_benches::index::vertex_label::run_benchmarks, previously in file /tmp/.tmp3Uy9nq/graph-api-benches/src/index/vertex_label/mod.rs:62
  function graph_api_benches::index::run_vertex_label_benchmarks, previously in file /tmp/.tmp3Uy9nq/graph-api-benches/src/index/vertex_label/mod.rs:62
  function graph_api_benches::index::vertex_range::run_benchmarks, previously in file /tmp/.tmp3Uy9nq/graph-api-benches/src/index/vertex_range/mod.rs:58
  function graph_api_benches::index::run_vertex_range_benchmarks, previously in file /tmp/.tmp3Uy9nq/graph-api-benches/src/index/vertex_range/mod.rs:58
  function graph_api_benches::index::vertex_hash::run_benchmarks, previously in file /tmp/.tmp3Uy9nq/graph-api-benches/src/index/vertex_hash/mod.rs:69
  function graph_api_benches::index::run_vertex_hash_benchmarks, previously in file /tmp/.tmp3Uy9nq/graph-api-benches/src/index/vertex_hash/mod.rs:69
  function graph_api_benches::index::vertex_full_text::run_benchmarks, previously in file /tmp/.tmp3Uy9nq/graph-api-benches/src/index/vertex_full_text/mod.rs:83
  function graph_api_benches::index::run_vertex_full_text_benchmarks, previously in file /tmp/.tmp3Uy9nq/graph-api-benches/src/index/vertex_full_text/mod.rs:83

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/inherent_method_missing.ron

Failed in:
  Vertex::person_by_unique_id, previously in file /tmp/.tmp3Uy9nq/graph-api-benches/src/index/vertex_hash/mod.rs:9
  Vertex::person_by_username, previously in file /tmp/.tmp3Uy9nq/graph-api-benches/src/index/vertex_range/mod.rs:8
  Vertex::person_by_username_range, previously in file /tmp/.tmp3Uy9nq/graph-api-benches/src/index/vertex_range/mod.rs:8
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `graph-api-lib`

<blockquote>

## [0.2.0] - 2025-04-20

### 🚀 Features

- [**breaking**] Move removal of elements to a supports trait (#76)
</blockquote>

## `graph-api-simplegraph`

<blockquote>

## [0.2.0] - 2025-04-20

### 🚀 Features

- [**breaking**] Move removal of elements to a supports trait (#76)
</blockquote>

## `graph-api-derive`

<blockquote>

## [0.1.4] - 2025-04-20

### 🐛 Bug Fixes

- VertexLabel names (#79)
- VertexLabel index types (#81)
</blockquote>

## `graph-api-test`

<blockquote>

## [0.2.0] - 2025-04-20

### 🚀 Features

- [**breaking**] Move removal of elements to a supports trait (#76)
</blockquote>

## `graph-api-benches`

<blockquote>

## [0.2.0] - 2025-04-20

### 🚀 Features

- [**breaking**] Move removal of elements to a supports trait (#76)
</blockquote>

## `graph-api-petgraph`

<blockquote>

## [0.1.5] - 2025-04-20

### ⚙️ Miscellaneous Tasks

- Updated the following local packages: graph-api-lib
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).